### PR TITLE
[TASK] Explicitly disable semantic commits

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
 		":separatePatchReleases",
 		":automergePatch",
 		":automergeRequireAllStatusChecks",
+		":semanticCommitsDisabled",
 		"config:recommended",
 		"mergeConfidence:all-badges",
 		"schedule:weekdays"


### PR DESCRIPTION
This PR explicitly disables semantic commits using the `:semanticCommitsDisabled` preset.