### PR TITLE
[FEATURE] Widen PHP version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Consider using more specific presets in your projects since they might be better
 |----------------------|-----------------------------------------|----------------------------------------------------------------------------------------|
 | Development packages | `devDependencies`, `require-dev`        | All packages used for development, updates in minor and patch range will be automerged |
 | PHPStan packages     | `phpstan/*`, various PHPStan extensions | PHPStan and extensions, will ge grouped as `PHPStan`                                   |
+| PHP version updates  | `php`                                   | PHP version will be widened and automerge is disabled                                  |
 
 ### Git Flow preset
 

--- a/default.json
+++ b/default.json
@@ -49,6 +49,16 @@
 				"saschaegerer/phpstan-typo3"
 			],
 			"groupName": "PHPStan"
+		},
+		{
+			"extends": [
+				":automergeDisabled"
+			],
+			"ignoreUnstable": false,
+			"matchPackageNames": [
+				"php"
+			],
+		    "rangeStrategy": "widen"
 		}
 	],
 	"prConcurrentLimit": 10,


### PR DESCRIPTION
This PR adds a package rule for `php` version updates: The current PHP version constraint is widened and automerge is disabled.