### PR TITLE
[BUGFIX] Use depName where applicable

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,7 +44,7 @@
 			"matchPackagePrefixes": [
 				"phpstan/"
 			],
-			"matchPackageNames": [
+			"matchDepNames": [
 				"jangregor/phpstan-prophecy",
 				"saschaegerer/phpstan-typo3"
 			],
@@ -55,7 +55,7 @@
 				":automergeDisabled"
 			],
 			"ignoreUnstable": false,
-			"matchPackageNames": [
+			"matchDepNames": [
 				"php"
 			],
 		    "rangeStrategy": "widen"


### PR DESCRIPTION
This PR switches from `packageName` to `depName`, because it is recommended to use `depName` wherever possible.