### PR TITLE
[TASK] Group `actions/*-artifact` actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -59,6 +59,13 @@
 				"php"
 			],
 			"rangeStrategy": "widen"
+		},
+		{
+			"matchDepNames": [
+				"actions/download-artifact",
+				"actions/upload-artifact"
+			],
+			"groupName": "GitHub artifact actions"
 		}
 	],
 	"prConcurrentLimit": 10,


### PR DESCRIPTION
This PR creates a new package rule which groups updates for `actions/*-artifact` actions, since they are tightly coupled to each other.