### PR TITLE
[TASK] Rebase stale PRs with default preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Consider using more specific presets in your projects since they might be better
 | [`:separatePatchReleases`][4]           | _Preset_            | Separate patch and minor releases into separate MRs                                     |
 | [`:automergePatch`][14]                 | _Preset_            | Automerge patch upgrades if they pass tests                                             |
 | [`:automergeRequireAllStatusChecks`][5] | _Preset_            | Require successful CI for auto-merge                                                    |
+| [`:rebaseStalePrs`][15]                 | _Preset_            | Rebase MRs if they're behind base branch                                                |
 | [`schedule:weekdays`][6]                | _Preset_            | Schedule one Renovate run per weekday (triggered by renovate/renovate-runner>)          |
 | [`configMigration`][7]                  | `true`              | Enables migration of Renovate config on a repository basis                              |
 | [`lockFileMaintenance`][8]              | `{"enabled": true}` | Enable dependency updates of all locked dependencies, including transitive dependencies |
@@ -177,4 +178,5 @@ This project is licensed under [GNU General Public License 3.0 (or later)](LICEN
 [12]: https://docs.renovatebot.com/configuration-options/#basebranches
 [13]: https://docs.renovatebot.com/configuration-options/#rangestrategy
 [14]: https://docs.renovatebot.com/presets-default/#automergepatch
+[15]: https://docs.renovatebot.com/presets-default/#rebasestaleprs
 [99]: https://github.com/pagemachine/renovate-config

--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
 		":separatePatchReleases",
 		":automergePatch",
 		":automergeRequireAllStatusChecks",
+		":rebaseStalePrs",
 		":semanticCommitsDisabled",
 		"config:recommended",
 		"mergeConfidence:all-badges",


### PR DESCRIPTION
This PR adds the `:rebaseStalePrs` preset to the default preset. It configures Renovate to rebase PRs that are behind the base branch.