### PR TITLE
[BUGFIX] Disable vulnerability alerts for TYPO3 CMS packages

### DIFF
--- a/typo3-project.json
+++ b/typo3-project.json
@@ -21,7 +21,8 @@
 			],
 			"groupName": "TYPO3 CMS",
 			"extends": [
-				":disableMajorUpdates"
+				":disableMajorUpdates",
+				":disableVulnerabilityAlerts"
 			],
 			"fetchReleaseNotes": false
 		}


### PR DESCRIPTION
This PR disables vulnerability alerts for the `TYPO3 CMS` package rule. TYPO3 CMS extensions are required to be in version sync, therefore updating only a single vulnerable package (only `typo3/cms-core` receives vulnerability alerts) fails.