### PR TITLE
[TASK] Disable automerge for TYPO3 CMS updates

### DIFF
--- a/typo3-project.json
+++ b/typo3-project.json
@@ -21,6 +21,7 @@
 			],
 			"groupName": "TYPO3 CMS",
 			"extends": [
+				":automergeDisabled",
 				":disableMajorUpdates",
 				":disableVulnerabilityAlerts"
 			],


### PR DESCRIPTION
Updates of TYPO3 CMS packages are potentially breaking and therefore need deeper verification and review. Thus, automerge for those packages is disabled with this PR.