### PR TITLE
[TASK] Disable OSV vulnerability alerts for TYPO3 project preset

### DIFF
--- a/typo3-project.json
+++ b/typo3-project.json
@@ -9,6 +9,7 @@
 	"lockFileMaintenance": {
 		"automerge": false
 	},
+	"osvVulnerabilityAlerts": false,
 	"rangeStrategy": "in-range-only",
 	"packageRules": [
 		{
@@ -22,11 +23,9 @@
 			"groupName": "TYPO3 CMS",
 			"extends": [
 				":automergeDisabled",
-				":disableMajorUpdates",
-				":disableVulnerabilityAlerts"
+				":disableMajorUpdates"
 			],
-			"fetchReleaseNotes": false,
-			"osvVulnerabilityAlerts": false
+			"fetchReleaseNotes": false
 		}
 	]
 }


### PR DESCRIPTION
This PR disables the `osvVulnerabilityAlerts` config option for TYPO3 projects, as it does not work reliably in TYPO3 context.